### PR TITLE
Add Close method to LocalStore interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,9 @@ type LocalStore interface {
 	// SetMeta persists the given top-level metadata in local storage, the
 	// name taking the same format as the keys returned by GetMeta.
 	SetMeta(name string, meta json.RawMessage) error
+
+	// Close closes local storage, frees up occupied resources.
+	Close() error
 }
 
 // RemoteStore downloads top-level metadata and target files from a remote

--- a/client/local_store.go
+++ b/client/local_store.go
@@ -18,3 +18,7 @@ func (m memoryLocalStore) SetMeta(name string, meta json.RawMessage) error {
 	m[name] = meta
 	return nil
 }
+
+func (m memoryLocalStore) Close() error {
+	return nil
+}


### PR DESCRIPTION
Close method closes local storage, frees up occupied resources.